### PR TITLE
feat: Add Azure OpenAI and custom model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ A Docusaurus plugin that adds an AI-powered chat interface to your documentation
 - 💅 Beautiful UI that matches your Docusaurus theme
 - ⚡ Real-time streaming responses
 - 📱 Responsive design
+- ☁️ Azure OpenAI and custom endpoint support
+- 🔧 Configurable embedding and chat models
 
 ## How It Works
 
@@ -79,6 +81,55 @@ module.exports = {
   },
 }
 ```
+
+### Custom Models
+
+You can specify custom embedding and chat models:
+
+```js
+module.exports = {
+  // ...
+  plugins: [
+    [
+      "docusaurus-plugin-chat-page",
+      {
+        path: "chat",
+        openai: {
+          apiKey: process.env.OPENAI_API_KEY,
+          embeddingModel: "text-embedding-3-large", // default: text-embedding-3-small
+          chatModel: "gpt-4o", // default: gpt-4o-mini
+        },
+      },
+    ],
+  ],
+}
+```
+
+### Azure OpenAI
+
+To use Azure OpenAI (or any OpenAI-compatible API), provide a custom `baseURL`:
+
+```js
+module.exports = {
+  // ...
+  plugins: [
+    [
+      "docusaurus-plugin-chat-page",
+      {
+        path: "chat",
+        openai: {
+          apiKey: process.env.AZURE_OPENAI_API_KEY,
+          baseURL: "https://your-resource.openai.azure.com/openai/v1/",
+          embeddingModel: "your-embedding-deployment-name",
+          chatModel: "your-chat-deployment-name",
+        },
+      },
+    ],
+  ],
+}
+```
+
+**Note:** For Azure OpenAI, the `embeddingModel` and `chatModel` should match your deployment names in Azure AI Foundry.
 
 ## Development Mode
 

--- a/src/services/ai.ts
+++ b/src/services/ai.ts
@@ -22,23 +22,33 @@ export function createAIService(
     throw new Error("OpenAI API key is required when not using mock data")
   }
 
-  const client = new OpenAI({
+  const clientConfig: { apiKey: string; dangerouslyAllowBrowser: boolean; baseURL?: string } = {
     apiKey: config.apiKey,
     dangerouslyAllowBrowser: true,
-  })
+  }
+
+  // Support Azure OpenAI or other OpenAI-compatible APIs via custom baseURL
+  if (config.baseURL) {
+    clientConfig.baseURL = config.baseURL
+  }
+
+  const embeddingModel = config.embeddingModel || "text-embedding-3-small"
+  const chatModel = config.chatModel || "gpt-4o-mini"
+
+  const client = new OpenAI(clientConfig)
 
   return {
     async generateEmbeddings(texts: string[]): Promise<number[][]> {
       const response = await client.embeddings.create({
         input: texts,
-        model: "text-embedding-3-small",
+        model: embeddingModel,
       })
       return response.data.map((item) => item.embedding)
     },
 
     async *generateChatCompletion(messages: ChatCompletionMessageParam[]) {
       const completion = await client.chat.completions.create({
-        model: "gpt-4o-mini",
+        model: chatModel,
         messages,
         stream: true,
       })

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,12 @@ export interface ChatPluginContent {
 
 export interface OpenAIConfig {
   apiKey: string
+  /** Custom base URL for Azure OpenAI or other OpenAI-compatible APIs */
+  baseURL?: string
+  /** Embedding model to use (default: text-embedding-3-small) */
+  embeddingModel?: string
+  /** Chat model to use (default: gpt-4o-mini) */
+  chatModel?: string
 }
 
 export interface DevelopmentConfig {


### PR DESCRIPTION
## Summary

This PR adds support for Azure OpenAI and custom OpenAI-compatible endpoints, as well as configurable model names.

### Changes

- **`baseURL` option**: Allows using Azure OpenAI or any OpenAI-compatible API endpoint
- **`embeddingModel` option**: Configure the embedding model (default: `text-embedding-3-small`)
- **`chatModel` option**: Configure the chat model (default: `gpt-4o-mini`)
- **Updated README**: Added documentation for custom models and Azure OpenAI configuration

### Use Cases

- **Azure OpenAI (Azure AI Foundry)**: Enterprise users can use their Azure deployments
- **Custom endpoints**: Support for local LLM servers or other OpenAI-compatible APIs
- **Model flexibility**: Choose different models based on cost/performance requirements

### Example Configuration

```js
// Azure OpenAI
{
  openai: {
    apiKey: process.env.AZURE_OPENAI_API_KEY,
    baseURL: "https://your-resource.openai.azure.com/openai/v1/",
    embeddingModel: "your-embedding-deployment",
    chatModel: "your-chat-deployment",
  },
}

// Custom models with standard OpenAI
{
  openai: {
    apiKey: process.env.OPENAI_API_KEY,
    embeddingModel: "text-embedding-3-large",
    chatModel: "gpt-4o",
  },
}
```

### Backward Compatibility

All new options are optional with sensible defaults, so existing configurations continue to work unchanged.

---

🤖 Generated with [Claude Code](https://claude.ai/code)