### PR TITLE
feat: Add embedding cache for faster builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # Generated files
 .docusaurus
 .cache-loader
+.embeddings-cache.json
 
 # Misc
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A Docusaurus plugin that adds an AI-powered chat interface to your documentation
 - 🔍 Semantic search using embeddings
 - 💨 Fast client-side similarity search
 - 🏗️ Build-time content processing
+- 💾 Embedding cache for fast rebuilds (no API costs)
 - 🔒 Secure (API keys only used at build time)
 - 💅 Beautiful UI that matches your Docusaurus theme
 - ⚡ Real-time streaming responses
@@ -124,6 +125,42 @@ When `mockData: true` is set:
 - A warning banner appears in the UI when mock data is enabled
 - Console warnings will indicate when mock services are being used
 - Production builds with `mockData: true` will show a warning
+
+## Embedding Cache
+
+The plugin automatically caches generated embeddings to avoid regenerating them on every build. This saves API costs and significantly speeds up subsequent builds.
+
+### How It Works
+
+1. **First build**: Generates embeddings via OpenAI API and saves them to `.embeddings-cache.json`
+2. **Subsequent builds**: Loads embeddings from cache (instant, no API calls)
+3. **Content changes**: Cache is automatically invalidated when documentation content changes
+4. **Model changes**: Cache is invalidated if you change the embedding model
+
+### Cache Behavior
+
+| Scenario | Behavior |
+|----------|----------|
+| First build | Generates embeddings, creates cache |
+| No content changes | Uses cache (fast, free) |
+| Documentation changed | Regenerates embeddings |
+| Different embedding model | Regenerates embeddings |
+| `mockData: true` | No cache (mock embeddings) |
+
+### Cache File
+
+The cache is stored in `.embeddings-cache.json` in your project root. You should:
+
+- **Add to `.gitignore`**: The cache file can be large and is machine-specific
+- **Delete to force regeneration**: Remove the file to regenerate all embeddings
+
+```bash
+# Add to .gitignore
+echo ".embeddings-cache.json" >> .gitignore
+
+# Force regeneration
+rm .embeddings-cache.json
+```
 
 ## Environment Variables
 

--- a/src/content.ts
+++ b/src/content.ts
@@ -1,17 +1,32 @@
 import { LoadContext } from "@docusaurus/types"
 import * as fs from "fs/promises"
 import * as path from "path"
+import * as crypto from "crypto"
 import type {
   FileNode,
   ChatPluginContent,
   OpenAIConfig,
   DevelopmentConfig,
+  DocumentChunkWithEmbedding,
 } from "./types"
 import { glob } from "glob"
 import matter from "gray-matter"
 import OpenAI from "openai"
 import process from "process"
 import { createAIService } from "./services/ai"
+
+// Cache file for persisted embeddings
+const CACHE_FILE = ".embeddings-cache.json"
+
+interface EmbeddingCache {
+  contentHash: string
+  embeddingModel: string
+  chunks: DocumentChunkWithEmbedding[]
+  metadata: {
+    totalChunks: number
+    lastUpdated: string
+  }
+}
 
 /**
  * Convert a flat list of file paths into a tree structure
@@ -306,7 +321,78 @@ async function generateEmbeddings(
 }
 
 /**
+ * Compute a hash of all content files for cache validation
+ */
+async function computeContentHash(dirs: string[]): Promise<string> {
+  const hash = crypto.createHash("sha256")
+
+  for (const dir of dirs) {
+    try {
+      const files = glob.sync("**/*.{md,mdx}", { cwd: dir, absolute: true })
+      files.sort() // Ensure consistent ordering
+
+      for (const file of files) {
+        const content = await fs.readFile(file, "utf-8")
+        hash.update(file)
+        hash.update(content)
+      }
+    } catch {
+      // Directory might not exist
+    }
+  }
+
+  return hash.digest("hex")
+}
+
+/**
+ * Load cached embeddings if valid
+ */
+async function loadCache(
+  cacheFile: string,
+  contentHash: string,
+  embeddingModel: string
+): Promise<EmbeddingCache | null> {
+  try {
+    const cacheContent = await fs.readFile(cacheFile, "utf-8")
+    const cache: EmbeddingCache = JSON.parse(cacheContent)
+
+    // Validate cache
+    if (cache.contentHash === contentHash && cache.embeddingModel === embeddingModel) {
+      return cache
+    }
+
+    console.log("Cache invalidated: content or model changed")
+    return null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Save embeddings to cache
+ */
+async function saveCache(
+  cacheFile: string,
+  contentHash: string,
+  embeddingModel: string,
+  chunks: DocumentChunkWithEmbedding[]
+): Promise<void> {
+  const cache: EmbeddingCache = {
+    contentHash,
+    embeddingModel,
+    chunks,
+    metadata: {
+      totalChunks: chunks.length,
+      lastUpdated: new Date().toISOString(),
+    },
+  }
+
+  await fs.writeFile(cacheFile, JSON.stringify(cache), "utf-8")
+}
+
+/**
  * Load all content and prepare for embedding generation
+ * Uses caching to avoid regenerating embeddings when content hasn't changed
  */
 export async function loadContent(
   context: LoadContext & {
@@ -318,6 +404,8 @@ export async function loadContent(
 ): Promise<ChatPluginContent> {
   const { siteDir, options } = context
   const useMockData = options?.development?.mockData === true
+  const embeddingModel = options?.openai?.embeddingModel || "text-embedding-3-small"
+  const cacheFile = path.join(siteDir, CACHE_FILE)
 
   if (!useMockData && !options?.openai?.apiKey) {
     throw new Error("OpenAI API key is required when not using mock data")
@@ -336,6 +424,28 @@ export async function loadContent(
 
   const docsDir = path.join(siteDir, "docs")
   const pagesDir = path.join(siteDir, "src/pages")
+  const contentDirs = [docsDir, pagesDir]
+
+  // Check cache (only for real embeddings, not mock data)
+  if (!useMockData) {
+    console.log("Computing content hash for cache validation...")
+    const contentHash = await computeContentHash(contentDirs)
+
+    const cache = await loadCache(cacheFile, contentHash, embeddingModel)
+    if (cache) {
+      console.log(
+        "\n\x1b[42m\x1b[30m CACHE HIT \x1b[0m Using cached embeddings!"
+      )
+      console.log(
+        `📦 ${cache.chunks.length} cached embeddings | Last updated: ${cache.metadata.lastUpdated}`
+      )
+      return {
+        chunks: cache.chunks,
+        metadata: cache.metadata,
+      }
+    }
+    console.log("Cache miss - generating new embeddings...")
+  }
 
   // Get the tree structures
   const [docsTree, pagesTree] = await Promise.all([
@@ -411,6 +521,13 @@ export async function loadContent(
     useMockData,
     10
   )
+
+  // Save to cache (only for real embeddings)
+  if (!useMockData) {
+    const contentHash = await computeContentHash(contentDirs)
+    await saveCache(cacheFile, contentHash, embeddingModel, chunksWithEmbeddings)
+    console.log(`\n\x1b[32m✓\x1b[0m Embeddings cached to ${CACHE_FILE}`)
+  }
 
   if (useMockData) {
     console.log(


### PR DESCRIPTION
## Summary

This PR adds embedding caching to avoid regenerating embeddings on every build. This significantly reduces API costs and speeds up subsequent builds.

## Features

- **SHA-256 content hash validation**: Cache is invalidated when documentation content changes
- **Model-aware caching**: Cache is invalidated when the embedding model is changed
- **Zero-config**: Works automatically, no configuration needed
- **Development mode aware**: No caching for mock/development mode (not needed)

## How It Works

1. **First build**: Generates embeddings via OpenAI API, saves to `.embeddings-cache.json`
2. **Subsequent builds**: Loads from cache (instant, no API calls)
3. **Content changed**: Cache auto-invalidated, regenerates embeddings

## Console Output

```
=== Starting content processing ===
Computing content hash for cache validation...

 CACHE HIT  Using cached embeddings!
📦 356 cached embeddings | Last updated: 2025-12-29T20:07:08.260Z
```

## Benefits

- **Cost savings**: Embeddings are only generated once per content change
- **Faster builds**: Cache hits are near-instant
- **Automatic invalidation**: No manual cache management needed
- **Backward compatible**: Existing configurations continue to work

## Testing

- [x] First build generates embeddings and creates cache
- [x] Subsequent builds use cache
- [x] Content changes invalidate cache
- [x] Model changes invalidate cache
- [x] Mock mode works without caching

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)